### PR TITLE
Upper bound on intertwiners not saved with vertex amplitude.

### DIFF
--- a/src/vertex.c
+++ b/src/vertex.c
@@ -395,15 +395,15 @@ MPI_MASTERONLY_START
         tag.Immirzi = IMMIRZI;
         memcpy(tag.two_js, two_js, 10 * sizeof(dspin));
         tag.two_i1_range[0] = two_i1_min_allowed;
-        tag.two_i1_range[2] = two_i1_max_allowed;
+        tag.two_i1_range[1] = two_i1_max_allowed;
         tag.two_i2_range[0] = two_i2_min_allowed;
-        tag.two_i2_range[2] = two_i2_max_allowed;
+        tag.two_i2_range[1] = two_i2_max_allowed;
         tag.two_i3_range[0] = two_i3_min_allowed;
-        tag.two_i3_range[2] = two_i3_max_allowed;
+        tag.two_i3_range[1] = two_i3_max_allowed;
         tag.two_i4_range[0] = two_i4_min_allowed;
-        tag.two_i4_range[2] = two_i4_max_allowed;
+        tag.two_i4_range[1] = two_i4_max_allowed;
         tag.two_i5_range[0] = two_i5_min_allowed;
-        tag.two_i5_range[2] = two_i5_max_allowed;
+        tag.two_i5_range[1] = two_i5_max_allowed;
         tag.Dl = Dl;
 
         TENSOR_TAG(t_full, &tag, sizeof(tag));
@@ -976,15 +976,15 @@ MPI_MASTERONLY_START
         tag.Immirzi = IMMIRZI;
         memcpy(tag.two_js, two_js, 10 * sizeof(dspin));
         tag.two_i1_range[0] = two_i1_min;
-        tag.two_i1_range[2] = two_i1_max;
+        tag.two_i1_range[1] = two_i1_max;
         tag.two_i2_range[0] = two_i2_min;
-        tag.two_i2_range[2] = two_i2_max;
+        tag.two_i2_range[1] = two_i2_max;
         tag.two_i3_range[0] = two_i3_min;
-        tag.two_i3_range[2] = two_i3_max;
+        tag.two_i3_range[1] = two_i3_max;
         tag.two_i4_range[0] = two_i4_min;
-        tag.two_i4_range[2] = two_i4_max;
+        tag.two_i4_range[1] = two_i4_max;
         tag.two_i5_range[0] = two_i5_min;
-        tag.two_i5_range[2] = two_i5_max;
+        tag.two_i5_range[1] = two_i5_max;
         tag.Dl = Dl;
 
         TENSOR_TAG(t_range, &tag, sizeof(tag));


### PR DESCRIPTION
The tag is defined as:

typedef struct sl2cfoam_vertex_tag {
    double Immirzi;
    sl2cfoam_dspin two_js[10];
    sl2cfoam_dspin two_i1_range[2];
    sl2cfoam_dspin two_i2_range[2];
    sl2cfoam_dspin two_i3_range[2];
    sl2cfoam_dspin two_i4_range[2];
    sl2cfoam_dspin two_i5_range[2];
    int Dl;
} sl2cfoam_vertex_tag;

So valid indices are only 0, and 1.
Doing something like tag->two_i1_range[2] =10 
is likely overwriting the value of sl2cfoam_dspin two_i2_range[0] , (which subsequently gets written with a correct value)
but this behavior is undefined.

The net result is that the upper bound of the intertwiner range is not saved for the vertex amplitude.
Without the fix, this value can be recovered independently using the input spins or by using the lower bound in combination with the tensor index dimension.

Not aware of library code that relies on this information being correct.